### PR TITLE
upa commands small changes

### DIFF
--- a/examples/confidential-coins/scripts/test_confidential_coins
+++ b/examples/confidential-coins/scripts/test_confidential_coins
@@ -83,9 +83,8 @@ pushd _test_confidential_coins
            --retries 3
 
     # Register a vk
-    upa registervk \
+    upa registervk ${APP_VKFILE} \
            --keyfile ${APP_KEYFILE} \
-           --vk-file ${APP_VKFILE} \
            --wait
 
     confidential-coins deploy \

--- a/examples/demo-app/core/scripts/test_demo_app
+++ b/examples/demo-app/core/scripts/test_demo_app
@@ -86,9 +86,8 @@ pushd _test_demo_app
            --retries 3
 
     # Register a vk
-    upa registervk \
+    upa registervk ${APP_VKFILE} \
            --keyfile ${APP_KEYFILE} \
-           --vk-file ${APP_VKFILE} \
            --wait
 
     demo-app deploy \

--- a/upa/scripts/test_dev_aggregator
+++ b/upa/scripts/test_dev_aggregator
@@ -78,9 +78,9 @@ pushd _test_dev_aggregator
     TEST_PROOFS=${UPA_DIR}/circuits/src/tests/data/universal_batch_verifier_8_proofs.json
 
     # Register VKs
-    KEYFILE=${KEYFILE} upa registervk --vk-file ${TEST_VK}
-    KEYFILE=${KEYFILE} upa registervk --vk-file ${VK_2}
-    KEYFILE=${KEYFILE} upa registervk --vk-file ${VK_3} --wait
+    KEYFILE=${KEYFILE} upa registervk ${TEST_VK}
+    KEYFILE=${KEYFILE} upa registervk ${VK_2}
+    KEYFILE=${KEYFILE} upa registervk ${VK_3} --wait
 
     # Check stats and record
     upa query stats > stats.0

--- a/upa/scripts/test_upa
+++ b/upa/scripts/test_upa
@@ -59,7 +59,7 @@ pushd _test_upa
 
     # Deploy a second agg proof verifier contract and use this.
     orig_agg_verifier=`upa query aggregated-proof-verifier`
-    orig_max_num_inputs=`upa query max-num-public-inputs`
+    orig_max_num_inputs=`upa query config | jq -r ".maxNumPublicInputs"`
     KEYFILE_PASSWORD=${DUMMY_PW} upa owner deploy-binary \
                     --keyfile ${KEYFILE} \
                     --dump-tx \
@@ -103,9 +103,8 @@ pushd _test_upa
 
     # Check that pausing works as expected
     KEYFILE_PASSWORD=${DUMMY_PW} upa owner pause --keyfile ${KEYFILE}
-    KEYFILE=${KEYFILE} KEYFILE_PASSWORD=${DUMMY_PW} upa registervk \
+    KEYFILE=${KEYFILE} KEYFILE_PASSWORD=${DUMMY_PW} upa registervk ${TEST_VK} \
               --password ${DUMMY_PW} \
-              --vk-file ${TEST_VK} \
               --wait > /dev/null 2>&1 || true
     ## Check that no vk was registered via stats
     upa query stats > stats.0
@@ -116,17 +115,14 @@ pushd _test_upa
     KEYFILE_PASSWORD=${DUMMY_PW} upa owner unpause --keyfile ${KEYFILE}
 
     # Register all VKs
-    KEYFILE=${KEYFILE} KEYFILE_PASSWORD=${DUMMY_PW} upa registervk \
+    KEYFILE=${KEYFILE} KEYFILE_PASSWORD=${DUMMY_PW} upa registervk ${TEST_VK} \
               --password ${DUMMY_PW} \
-              --vk-file ${TEST_VK}
 
-    KEYFILE=${KEYFILE} KEYFILE_PASSWORD=${DUMMY_PW} upa registervk \
+    KEYFILE=${KEYFILE} KEYFILE_PASSWORD=${DUMMY_PW} upa registervk submit-multi-4.vk-0.json \
               --password ${DUMMY_PW} \
-              --vk-file submit-multi-4.vk-0.json
 
-    KEYFILE=${KEYFILE} KEYFILE_PASSWORD=${DUMMY_PW} upa registervk \
+    KEYFILE=${KEYFILE} KEYFILE_PASSWORD=${DUMMY_PW} upa registervk submit-multi-4.vk-1.json \
               --password ${DUMMY_PW} \
-              --vk-file submit-multi-4.vk-1.json \
               --wait
 
     # Check stats and record

--- a/upa/src/tool/options.ts
+++ b/upa/src/tool/options.ts
@@ -118,15 +118,6 @@ export function vkProofInputsFile(): Option {
   });
 }
 
-export function vkFile(): Option {
-  return option({
-    type: string,
-    long: "vk-file",
-    short: "v",
-    description: "Verifying key file",
-  });
-}
-
 /// A JSON file in one of the formats:
 /// - An array of { vk, proof, inputs }
 /// - An array of { circuitId, proof, inputs }

--- a/upa/src/tool/query.ts
+++ b/upa/src/tool/query.ts
@@ -3,24 +3,9 @@ import { stats } from "./stats";
 import { getConfig } from "./getConfig";
 import { endpoint, instance } from "./options";
 import { ethers } from "ethers";
-import { config } from ".";
 import { upaFromInstanceFile } from "./config";
 import { isVerified, isSubmissionVerified } from "./isVerified";
 import { getAggregatedProofVerifier } from "./aggregatedProofVerifier";
-
-const getMaxNumPublicInputs = command({
-  name: "max-num-public-inputs",
-  args: {
-    endpoint: endpoint(),
-    instance: instance(),
-  },
-  description: "Get the current maximum number of public inputs supported",
-  handler: async function ({ endpoint, instance }): Promise<void> {
-    const provider = new ethers.JsonRpcProvider(endpoint);
-    const { verifier } = await config.upaFromInstanceFile(instance, provider);
-    console.log(await verifier.maxNumPublicInputs());
-  },
-});
 
 const getVerifierByteCode = command({
   name: "verifier-bytecode",
@@ -51,7 +36,6 @@ export const query = subcommands({
     "aggregated-proof-verifier": getAggregatedProofVerifier,
     stats,
     config: getConfig,
-    "max-num-public-inputs": getMaxNumPublicInputs,
     "verifier-bytecode": getVerifierByteCode,
     "is-verified": isVerified,
     "is-submission-verified": isSubmissionVerified,

--- a/upa/src/tool/registerVK.ts
+++ b/upa/src/tool/registerVK.ts
@@ -1,4 +1,4 @@
-import { command } from "cmd-ts";
+import { command, positional, string } from "cmd-ts";
 import {
   instance,
   keyfile,
@@ -6,7 +6,6 @@ import {
   wait,
   password,
   getPassword,
-  vkFile,
   estimateGas,
   dumpTx,
 } from "./options";
@@ -29,7 +28,11 @@ export const registervk = command({
     estimateGas: estimateGas(),
     dumpTx: dumpTx(),
     wait: wait(),
-    vkFile: vkFile(),
+    vkFile: positional({
+      type: string,
+      displayName: "vk-file",
+      description: "JSON VK file for the circuit",
+    }),
   },
   handler: async function ({
     endpoint,


### PR DESCRIPTION
- [x] Set a valid title
- [x] Use branch-name `[<ref>-]<feature-description>`
- [x] Brief description of the changes
- [x] Create matching PRs in dependent repos

`upa registervk` takes the vk file as a positional argument to be a bit more consistent with other commands like `upa compute circuitid`

Removes `upa query max-num-public-inputs` because that info is contained in `upa query config`

Can also include any other small changes we want to do