### PR TITLE
keccak circuit computes submission id

### DIFF
--- a/circuits/src/keccak/mod.rs
+++ b/circuits/src/keccak/mod.rs
@@ -1049,10 +1049,6 @@ where
             0,
             "The number of (padded) proof ids must be a power of two in submission id mode"
         );
-        assert!(
-            total_num_proof_ids > 1,
-            "Only circuits with more than 1 proof id supported"
-        );
 
         let zero = ctx.load_constant(F::zero());
         let bitmask = first_i_bits_bitmask(
@@ -1114,8 +1110,11 @@ where
             subtree_roots.push(current_row[0].clone());
         }
 
+        // This is just a matrix transposition
         (0..32)
             .map(|i| subtree_roots.iter().map(|inner| inner[i]).collect_vec())
+            // For each column, we select the byte determined by the next power
+            // of two
             .map(|inner| {
                 range
                     .gate
@@ -1182,7 +1181,7 @@ where
             "Config incompatible with inputs"
         );
         let num_proof_ids =
-            inputs.num_proof_ids.map(|npi| ctx.load_constant(npi));
+            inputs.num_proof_ids.map(|npi| ctx.load_witness(npi));
         if config.output_submission_id {
             range.check_less_than_safe(
                 ctx,

--- a/circuits/src/outer/mod.rs
+++ b/circuits/src/outer/mod.rs
@@ -197,6 +197,7 @@ impl<O: OuterCircuit> OuterInstanceInputs<O> {
     ) -> Self {
         let bv_config = O::bv_config(config);
         let mut keccak_config = O::keccak_config(config);
+        // Changed so the assertions in the functions below pass
         keccak_config.output_submission_id = false;
         // Compute the expected keccak instance given the bv instances, and
         // compare.
@@ -215,8 +216,8 @@ impl<O: OuterCircuit> OuterInstanceInputs<O> {
         // we don't compare those elements
         let keccak_instance_len = keccak_instance.len();
         assert_eq!(
-            expected_keccak_instance[keccak_instance_len - 2..],
-            keccak_instance[keccak_instance_len - 2..]
+            expected_keccak_instance[..keccak_instance_len - 2],
+            keccak_instance[..keccak_instance_len - 2]
         );
 
         Self {

--- a/prover/scripts/test_prover
+++ b/prover/scripts/test_prover
@@ -31,7 +31,8 @@ pushd _test_prover
 
     if [ "${OUTPUT_SUBMISSION_ID}" == "1" ]; then
       submission_size=$((inner_batch_size * outer_batch_size))
-      NUM_PROOF_IDS="--num-proof-ids ${submission_size}"
+      num_proof_ids=$((submission_size / 2))
+      NUM_PROOF_IDS="--num-proof-ids ${num_proof_ids}"
     fi
 
     # Create `inner_batch_size` (unsafe) keys.

--- a/upa/src/tool/deploy.ts
+++ b/upa/src/tool/deploy.ts
@@ -64,7 +64,7 @@ type DeployArgs = {
   endpoint: string;
   keyfile: string;
   password: string;
-  verifier_bin?: string;
+  verifierBin?: string;
   instance: string;
   upaConfigFile: string;
   useTestConfig: boolean;
@@ -77,7 +77,7 @@ type DeployArgs = {
   aggregatorCollateralInWei?: string;
   groth16VerifierAddress?: string;
   fixedReimbursementInWei?: string;
-  sid_verifier_bin?: string;
+  sidVerifierBin?: string;
 };
 
 const deployHandler = async function (args: DeployArgs): Promise<void> {
@@ -98,7 +98,7 @@ const deployHandler = async function (args: DeployArgs): Promise<void> {
     endpoint,
     keyfile,
     password,
-    verifier_bin,
+    verifierBin,
     instance,
     upaConfigFile,
     useTestConfig,
@@ -109,7 +109,7 @@ const deployHandler = async function (args: DeployArgs): Promise<void> {
     aggregatorCollateralInWei,
     groth16VerifierAddress,
     fixedReimbursementInWei,
-    sid_verifier_bin,
+    sidVerifierBin,
     maxRetries,
     prepare,
   } = args;
@@ -138,11 +138,11 @@ const deployHandler = async function (args: DeployArgs): Promise<void> {
     : loadUpaConfig(upaConfigFile).max_num_app_public_inputs;
 
   // Load binary contract
-  const contract_hex = verifier_bin
-    ? "0x" + fs.readFileSync(verifier_bin, "utf-8").trim()
+  const contract_hex = verifierBin
+    ? "0x" + fs.readFileSync(verifierBin, "utf-8").trim()
     : undefined;
-  const sid_contract_hex = sid_verifier_bin
-    ? "0x" + fs.readFileSync(sid_verifier_bin, "utf-8").trim()
+  const sid_contract_hex = sidVerifierBin
+    ? "0x" + fs.readFileSync(sidVerifierBin, "utf-8").trim()
     : undefined;
   const upaInstance = await deployUpa(
     wallet,
@@ -197,12 +197,12 @@ export const deploy = command({
       long: "use-test-config",
       description: "Use a default UPA config for testing",
     }),
-    verifier_bin: option({
+    verifierBin: option({
       type: optional(string),
       long: "verifier",
       description: "On-chain verifier binary",
     }),
-    sid_verifier_bin: option({
+    sidVerifierBin: option({
       type: optional(string),
       long: "sid-verifier",
       description: "Submission-id on-chain verifier binary",
@@ -305,7 +305,7 @@ export async function deployUpaDependencies(
   };
 }
 
-/// Deploys the UPA contract, with all dependencies.  `verifier_bin_file`
+/// Deploys the UPA contract, with all dependencies.  `verifierBinFile`
 /// points to the hex representation of the verifier byte code (as output by
 /// solidity). The address of `signer` is used by default for `owner` and
 /// `worker` if they are not given.

--- a/upa/src/tool/deployBinary.ts
+++ b/upa/src/tool/deployBinary.ts
@@ -16,7 +16,7 @@ export const deployBinary = command({
     estimateGas: options.estimateGas(),
     dumpTx: options.dumpTx(),
     wait: options.wait(),
-    verifier_bin: positional({
+    verifierBin: positional({
       type: string,
       description: "On-chain verifier binary file",
     }),
@@ -29,13 +29,13 @@ export const deployBinary = command({
     estimateGas,
     dumpTx,
     wait,
-    verifier_bin,
+    verifierBin,
   }): Promise<void> {
     const provider = new ethers.JsonRpcProvider(endpoint);
     const wallet = await loadWallet(keyfile, getPassword(password), provider);
 
     // Load binary contract
-    const contractHex = "0x" + fs.readFileSync(verifier_bin, "utf-8").trim();
+    const contractHex = "0x" + fs.readFileSync(verifierBin, "utf-8").trim();
 
     const txReq = await utils.populateDeployBinaryContract(wallet, contractHex);
 


### PR DESCRIPTION
- [ ] Set a valid title
- [ ] Use branch-name `[<ref>-]<feature-description>`
- [ ] Brief description of the changes
- [ ] Create matching PRs in dependent repos

Changes:
- Adds an option to the keccak circuit so it computes the submission id (as the Merkle root of the proof ids, padded to the total batch size of the config)
- Adds a new entry point to the Verifier contract to verify such proofs