### PR TITLE
fix[mergeSubmissionIntervals]: allow merging dummy intervals

### DIFF
--- a/upa/src/sdk/submissionIntervals.ts
+++ b/upa/src/sdk/submissionIntervals.ts
@@ -5,6 +5,7 @@ import { Submission, SubmissionProof } from "./submission";
 import { JSONstringify } from "./utils";
 import { DUMMY_PROOF_ID } from "./application";
 import { strict as assert } from "assert";
+import { log } from "../tool";
 
 // For inner / outer batches that contain full or partial multi-proof
 // submissions, we must track the sub-vector of proofs from each submission.
@@ -131,7 +132,6 @@ export function mergeSubmissionIntervals<T>(
 
   const mergedIntervals: SubmissionInterval<T>[] = [];
   let curInterval = intervals[0];
-  let doNotMerge = false;
 
   for (let i = 1; i < intervals.length; ++i) {
     const nextInterval = intervals[i];
@@ -145,10 +145,8 @@ export function mergeSubmissionIntervals<T>(
         isDummySubmissionInterval(nextInterval),
         `Non-dummy proof after dummy proof in batch`
       );
-      // No intervals shall be merged past this point
-      doNotMerge = true;
     }
-    if (!doNotMerge && siCanMerge(curInterval, nextInterval)) {
+    if (siCanMerge(curInterval, nextInterval)) {
       // The intervals can be merged.  Add next into current.
       curInterval = {
         submission: curInterval.submission,

--- a/upa/src/sdk/submissionIntervals.ts
+++ b/upa/src/sdk/submissionIntervals.ts
@@ -139,9 +139,8 @@ export function mergeSubmissionIntervals<T>(
     const nextInterval = intervals[i];
 
     if (isDummySubmissionInterval(curInterval)) {
-      // The current submission is the dummy proof.
-      // After this only more dummy submissions are allowed, and
-      // they won't be merged.
+      // The current submission is made of dummy proofs.
+      // After this only more dummy submissions are allowed.
       // Assert the next submission is also a dummy submission.
       assert(
         isDummySubmissionInterval(nextInterval),
@@ -172,6 +171,9 @@ export function mergeSubmissionIntervals<T>(
       const curMetadata = curInterval.data as OffChainSubmissionMetadata;
       const nextMetadata = nextInterval.data as OffChainSubmissionMetadata;
 
+      // If we split an on-chain submission, between 2 aggregated batches,
+      // We need to allow the second part of the on-chain submission
+      // to start with index > 0 when following an off-chain submission.
       if (
         curMetadata?.isOffChainSubmission ===
           nextMetadata?.isOffChainSubmission &&

--- a/upa/src/sdk/submissionIntervals.ts
+++ b/upa/src/sdk/submissionIntervals.ts
@@ -5,7 +5,6 @@ import { Submission, SubmissionProof } from "./submission";
 import { JSONstringify } from "./utils";
 import { DUMMY_PROOF_ID } from "./application";
 import { strict as assert } from "assert";
-import { log } from "../tool";
 
 // For inner / outer batches that contain full or partial multi-proof
 // submissions, we must track the sub-vector of proofs from each submission.

--- a/upa/src/sdk/submissionIntervals.ts
+++ b/upa/src/sdk/submissionIntervals.ts
@@ -173,8 +173,9 @@ export function mergeSubmissionIntervals<T>(
       const nextMetadata = nextInterval.data as OffChainSubmissionMetadata;
 
       if (
-        nextInterval.startIdx !== 0 &&
-        curMetadata?.isOffChainSubmission === nextMetadata?.isOffChainSubmission
+        curMetadata?.isOffChainSubmission ===
+          nextMetadata?.isOffChainSubmission &&
+        nextInterval.startIdx !== 0
       ) {
         throw `SubmissionInterval misses head:
                     ${JSONstringify(nextInterval)}`;

--- a/upa/src/sdk/submissionIntervals.ts
+++ b/upa/src/sdk/submissionIntervals.ts
@@ -6,6 +6,9 @@ import { JSONstringify } from "./utils";
 import { DUMMY_PROOF_ID } from "./application";
 import { strict as assert } from "assert";
 
+type OffChainSubmissionMetadata =
+  | { isOffChainSubmission?: boolean }
+  | undefined;
 // For inner / outer batches that contain full or partial multi-proof
 // submissions, we must track the sub-vector of proofs from each submission.
 export type SubmissionInterval<T = undefined> = {
@@ -166,7 +169,13 @@ export function mergeSubmissionIntervals<T>(
                     ${JSONstringify(curInterval)}`;
       }
 
-      if (nextInterval.startIdx !== 0) {
+      const curMetadata = curInterval.data as OffChainSubmissionMetadata;
+      const nextMetadata = nextInterval.data as OffChainSubmissionMetadata;
+
+      if (
+        nextInterval.startIdx !== 0 &&
+        curMetadata?.isOffChainSubmission === nextMetadata?.isOffChainSubmission
+      ) {
         throw `SubmissionInterval misses head:
                     ${JSONstringify(nextInterval)}`;
       }


### PR DESCRIPTION
* [x] `mergeSubmissionIntervals`: allowing merging dummy intervals as that can now have more than 1 proof