### PR TITLE
Fix typos in UpaVerifier contract and tests

### DIFF
--- a/upa/contracts/UpaVerifier.sol
+++ b/upa/contracts/UpaVerifier.sol
@@ -105,7 +105,7 @@ contract UpaVerifier is
         /// from which height they should start reading proofs.
         uint64 lastVerifiedSubmissionHeight;
         /// Open censorship challenges. The key is the `submissionId`, the
-        /// value is the amount to refund if the challenge is sucessful.
+        /// value is the amount to refund if the challenge is successful.
         mapping(bytes32 => uint256) openChallengeRefundAmounts;
         /// Fixed reimbursement for censorship challenges. The aggregator must
         /// pay the claimant this amount upon the completion of a successful
@@ -1038,7 +1038,7 @@ contract UpaVerifier is
     ) external returns (bool challengeSuccessful) {
         emit Challenge();
 
-        // We track the gas to reimburse the costs to sucessful
+        // We track the gas to reimburse the costs to successful
         // challenges
         uint256 startGas = gasleft();
 

--- a/upa/test/upaTests.ts
+++ b/upa/test/upaTests.ts
@@ -570,14 +570,14 @@ describe("UPA", async () => {
         );
       // If the fee recipient claims it, it will succeed. Let's check the
       // fee recipient received the funds.
-      const feeRecipentBalanceBeforeClaim = await ethers.provider.getBalance(
+      const feeRecipientBalanceBeforeClaim = await ethers.provider.getBalance(
         feeRecipient
       );
       const claimTx = await verifier.connect(feeRecipient).claimAggregatorFee();
       const claimTxReceipt = await claimTx.wait();
       const claimTxCost = claimTxReceipt!.gasUsed * claimTxReceipt!.gasPrice;
       expect(await ethers.provider.getBalance(feeRecipient)).equals(
-        feeRecipentBalanceBeforeClaim - claimTxCost + feeDue
+        feeRecipientBalanceBeforeClaim - claimTxCost + feeDue
       );
       // And that the due balance is reset to zero.
       expect(await verifier.feeAllocated()).equals(0n);


### PR DESCRIPTION
This PR fixes several spelling mistakes:

- Corrects "sucessful" to "successful" in UpaVerifier.sol comments
- Fixes variable name typo "feeRecipentBalanceBeforeClaim" to "feeRecipientBalanceBeforeClaim" in upaTests.ts

These changes are purely cosmetic and do not affect any functionality.