### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/circuits.yml
+++ b/.github/workflows/circuits.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/confidential-coins.yml
+++ b/.github/workflows/confidential-coins.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Based on https://github.com/actions/cache/blob/main/examples.md#node---yarn-2
       - name: Get yarn cache directory path

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/demo-app.yml
+++ b/.github/workflows/demo-app.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Based on https://github.com/actions/cache/blob/main/examples.md#node---yarn-2
       - name: Get yarn cache directory path

--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected