### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/circuits.yml
+++ b/.github/workflows/circuits.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       # For EC2 runner
       - name: Set HOME env variable

--- a/.github/workflows/confidential-coins.yml
+++ b/.github/workflows/confidential-coins.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       # For EC2 runner
       - name: Set HOME env variable

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -18,7 +18,7 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       # For EC2 runner
       - name: Set HOME env variable

--- a/.github/workflows/demo-app.yml
+++ b/.github/workflows/demo-app.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       # For EC2 runner
       - name: Set HOME env variable

--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       # For EC2 runner
       - name: Set HOME env variable


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0